### PR TITLE
Feature/rework uri router

### DIFF
--- a/android/src/main/java/nolambda/linkrouter/android/UriRouterFactory.kt
+++ b/android/src/main/java/nolambda/linkrouter/android/UriRouterFactory.kt
@@ -1,6 +1,6 @@
 package nolambda.linkrouter.android
 
-import nolambda.linkrouter.DeepLinkEntry
+import nolambda.linkrouter.DeepLinkUri
 import nolambda.linkrouter.KeyUriRouter
 import nolambda.linkrouter.SimpleUriRouter
 import nolambda.linkrouter.UriRouter
@@ -8,7 +8,7 @@ import nolambda.linkrouter.UriRouterLogger
 
 class KeyUriRouterFactory(
     private val logger: UriRouterLogger? = RouterPlugin.logger,
-    private val keyExtractor: (DeepLinkEntry) -> String = { entry -> "${entry.uri.scheme}${entry.uri.host}" }
+    private val keyExtractor: (DeepLinkUri) -> String = { uri -> "${uri.scheme}${uri.host}" }
 ) : UriRouterFactory {
     override fun create(): UriRouter<UriResult> {
         return KeyUriRouter(logger, keyExtractor)

--- a/android/src/main/java/nolambda/linkrouter/android/UriRouterFactory.kt
+++ b/android/src/main/java/nolambda/linkrouter/android/UriRouterFactory.kt
@@ -5,6 +5,7 @@ import nolambda.linkrouter.KeyUriRouter
 import nolambda.linkrouter.SimpleUriRouter
 import nolambda.linkrouter.UriRouter
 import nolambda.linkrouter.UriRouterLogger
+import java.util.concurrent.ConcurrentHashMap
 
 class KeyUriRouterFactory(
     private val logger: UriRouterLogger? = RouterPlugin.logger,
@@ -16,10 +17,18 @@ class KeyUriRouterFactory(
 }
 
 class SimpleUriRouterFactory(
-    private val logger: UriRouterLogger? = RouterPlugin.logger
+    private val logger: UriRouterLogger? = RouterPlugin.logger,
+    private val isSupportConcurrent: Boolean = false
 ) : UriRouterFactory {
     override fun create(): UriRouter<UriResult> {
-        return SimpleUriRouter(logger)
+        return SimpleUriRouter(
+            logger = logger,
+            dataHolder = if (isSupportConcurrent) {
+                ConcurrentHashMap()
+            } else {
+                mutableMapOf()
+            }
+        )
     }
 }
 

--- a/android/src/main/java/nolambda/linkrouter/android/registerstrategy/LazyRegisterStrategy.kt
+++ b/android/src/main/java/nolambda/linkrouter/android/registerstrategy/LazyRegisterStrategy.kt
@@ -9,6 +9,13 @@ import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.Future
 
+/**
+ * Register simple route immediately but lazy register uri routes concurrently.
+ * For now the only compatible way to use this is to set
+ * [nolambda.linkrouter.android.SimpleUriRouterFactory.isSupportConcurrent] to true
+ *
+ * @see [nolambda.linkrouter.android.SimpleUriRouterFactory]
+ */
 class LazyRegisterStrategy<Extra>(
     private val executor: ExecutorService = Executors.newFixedThreadPool(2)
 ) : RegisterStrategy<Extra> {

--- a/android/src/test/java/nolambda/linkrouter/android/AndroidPerformanceTest.kt
+++ b/android/src/test/java/nolambda/linkrouter/android/AndroidPerformanceTest.kt
@@ -8,7 +8,10 @@ import kotlin.system.measureTimeMillis
 
 class AndroidPerformanceTest : StringSpec({
     val eagerRouter = object : AbstractAppRouter<Unit>() {}
-    val lazyRouter = object : AbstractAppRouter<Unit>(registerStrategy = LazyRegisterStrategy()) {}
+    val lazyRouter = object : AbstractAppRouter<Unit>(
+        registerStrategy = LazyRegisterStrategy(),
+        uriRouterFactory = SimpleUriRouterFactory(isSupportConcurrent = true)
+    ) {}
 
     val size = 10_000L
 

--- a/core/src/main/java/nolambda/linkrouter/DeepLinkEntry.kt
+++ b/core/src/main/java/nolambda/linkrouter/DeepLinkEntry.kt
@@ -18,10 +18,13 @@ class DeepLinkEntry private constructor(
         private val PARAM_PATTERN = Pattern.compile(PARAM_REGEX)
 
         fun parse(url: String): DeepLinkEntry {
-            val parsedUri = url.toDeepLinkUri()
-            val schemeHostAndPath = schemeHostAndPath(parsedUri)
+            return parse(url.toDeepLinkUri())
+        }
+
+        fun parse(deepLinkUri: DeepLinkUri): DeepLinkEntry {
+            val schemeHostAndPath = schemeHostAndPath(deepLinkUri)
             val regex = Pattern.compile(schemeHostAndPath.replace(PARAM_REGEX.toRegex(), PARAM_VALUE) + "$")
-            return DeepLinkEntry(parsedUri, regex, parseParameters(parsedUri))
+            return DeepLinkEntry(deepLinkUri, regex, parseParameters(deepLinkUri))
         }
 
         private fun schemeHostAndPath(uri: DeepLinkUri): String {

--- a/core/src/main/java/nolambda/linkrouter/KeyUriRouter.kt
+++ b/core/src/main/java/nolambda/linkrouter/KeyUriRouter.kt
@@ -1,55 +1,121 @@
 package nolambda.linkrouter
 
-import nolambda.linkrouter.matcher.DeepLinkEntryMatcher
+import nolambda.linkrouter.DeepLinkUri.Companion.toDeepLinkUri
 import nolambda.linkrouter.matcher.UriMatcher
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.CopyOnWriteArraySet
 
+/**
+ * router that use "key" to group [DeepLinkUri] or [DeepLinkEntry] for faster
+ * register and lookup
+ *
+ * Please note, this router addition process is not thread-safe.
+ */
 class KeyUriRouter<URI>(
-    logger: UriRouterLogger? = null,
-    private val keyExtractor: (DeepLinkEntry) -> String
+    private val logger: UriRouterLogger? = null,
+    private val keyExtractor: (DeepLinkUri) -> String
 ) : UriRouter<URI>(logger) {
 
-    private val entryContainer = ConcurrentHashMap<String, MutableSet<DeepLinkEntry>>()
+    private val keyToUriMap = mutableMapOf<String, MutableSet<Pair<DeepLinkUri, UriMatcher>>>()
+    private val keyToEntryMap = mutableMapOf<String, MutableSet<Pair<DeepLinkEntry, UriMatcher>>>()
+
+    private val handlerMap = mutableMapOf<DeepLinkUri, UriRouterHandler<URI>>()
 
     override fun clear() {
-        super.clear()
-        entryContainer.clear()
+        keyToUriMap.clear()
     }
 
     override fun resolveEntry(route: String): Pair<DeepLinkEntry, EntryValue<URI>>? {
-        val entry = DeepLinkEntry.parse(route)
-        val key = keyExtractor(entry)
-        val list = entryContainer[key]
+        val deepLinkUri = route.toDeepLinkUri()
+        val key = keyExtractor(deepLinkUri)
 
-        val actualKey = list?.firstOrNull { it.matches(route) } ?: return null
-
-        val entryValue = entries[actualKey]!!
-        if (entryValue.matcher == DeepLinkEntryMatcher) {
-            return actualKey to entryValue
+        logger?.run {
+            invoke("Key: $key")
+            invoke("Entries map size: ${keyToEntryMap.size}")
+            invoke("Uri map size: ${keyToUriMap.size}")
         }
-        // to support custom matcher
-        return if (entryValue.matcher.match(actualKey, route)) {
-            return actualKey to entryValue
-        } else null
+
+        val result = getResultFromEntryMap(key, route)
+        return if (result == null) {
+            logger?.invoke("Get from uri map for key: $key")
+            getResultFromUriMap(key, route).also {
+                /**
+                 * Because it's already available in [keyToEntryMap] remove the old data in [keyToUriMap]
+                 */
+                keyToUriMap.remove(key)
+            }
+        } else result
     }
 
+    private fun getResultFromUriMap(
+        key: String,
+        route: String
+    ): Pair<DeepLinkEntry, EntryValue<URI>>? {
+
+        var entry: DeepLinkEntry? = null
+        var matcher: UriMatcher? = null
+
+        val uriList = keyToUriMap[key] ?: return null
+        val actualKey = uriList.firstOrNull { pair ->
+            entry = DeepLinkEntry.parse(pair.first)
+            matcher = pair.second
+
+            // Add parsed entry to entry map
+            val sets = keyToEntryMap.getOrPut(key) { mutableSetOf() }
+            sets.add(entry!! to matcher!!)
+
+            matcher!!.match(entry!!, route)
+        } ?: return null
+
+        return createResult(actualKey.first, entry, matcher)
+    }
+
+    private fun getResultFromEntryMap(
+        key: String,
+        route: String
+    ): Pair<DeepLinkEntry, EntryValue<URI>>? {
+        val set = keyToEntryMap[key] ?: return null
+        val actualKey = set.firstOrNull { (entry, matcher) ->
+            matcher.match(entry, route)
+        } ?: return null
+
+        return createResult(actualKey.first.uri, actualKey.first, actualKey.second)
+    }
+
+    private fun createResult(
+        keyUri: DeepLinkUri,
+        entry: DeepLinkEntry?,
+        matcher: UriMatcher?
+    ): Pair<DeepLinkEntry, EntryValue<URI>> {
+        val handler = handlerMap[keyUri] ?: error("Handler not available for $keyUri")
+
+        return Pair(
+            first = entry ?: error("Entry not available fro $keyUri"),
+            second = EntryValue(
+                handler,
+                matcher ?: error("Matcher not available fro $keyUri")
+            )
+        )
+    }
+
+    /**
+     * This is not thread-safe
+     */
     override fun addEntry(
         vararg uri: String,
         matcher: UriMatcher,
         handler: UriRouterHandler<URI>
     ) {
-        val deepLinkEntries = uri.map { DeepLinkEntry.parse(it) }
-        deepLinkEntries.forEach { entry ->
-            entries[entry] = EntryValue(handler, matcher)
+        uri.forEach {
+            val deepLinkUri = it.toDeepLinkUri()
+            val key = keyExtractor(deepLinkUri)
 
-            val key = keyExtractor(entry)
-            inputToEntryContainer(key, entry)
+            inputToEntryContainer(key, deepLinkUri, matcher)
+
+            handlerMap[deepLinkUri] = handler
         }
     }
 
-    private fun inputToEntryContainer(key: String, entry: DeepLinkEntry) {
-        val entriesHolder = entryContainer.getOrPut(key) { CopyOnWriteArraySet() }
-        entriesHolder.add(entry)
+    private fun inputToEntryContainer(key: String, uri: DeepLinkUri, matcher: UriMatcher) {
+        val entriesHolder = keyToUriMap.getOrPut(key) { mutableSetOf() }
+        entriesHolder.add(uri to matcher)
     }
 }

--- a/core/src/main/java/nolambda/linkrouter/SimpleUriRouter.kt
+++ b/core/src/main/java/nolambda/linkrouter/SimpleUriRouter.kt
@@ -1,11 +1,28 @@
 package nolambda.linkrouter
 
-class SimpleUriRouter<RES>(logger: UriRouterLogger? = null) : UriRouter<RES>(logger) {
+import nolambda.linkrouter.matcher.UriMatcher
+
+class SimpleUriRouter<RES>(private val logger: UriRouterLogger? = null) : UriRouter<RES>(logger) {
+
+    private val entries: MutableMap<DeepLinkEntry, EntryValue<RES>> = mutableMapOf()
 
     override fun resolveEntry(route: String): Pair<DeepLinkEntry, EntryValue<RES>>? {
+        logger?.invoke("Entries size: ${entries.size}")
+
         return entries.asSequence().firstOrNull { entry ->
             val value = entry.value
             value.matcher.match(entry.key, route)
         }?.toPair()
+    }
+
+    override fun addEntry(vararg uri: String, matcher: UriMatcher, handler: UriRouterHandler<RES>) {
+        val deepLinkEntries = uri.map { DeepLinkEntry.parse(it) }
+        deepLinkEntries.forEach { entry ->
+            entries[entry] = EntryValue(handler, matcher)
+        }
+    }
+
+    override fun clear() {
+        entries.clear()
     }
 }

--- a/core/src/main/java/nolambda/linkrouter/SimpleUriRouter.kt
+++ b/core/src/main/java/nolambda/linkrouter/SimpleUriRouter.kt
@@ -2,9 +2,12 @@ package nolambda.linkrouter
 
 import nolambda.linkrouter.matcher.UriMatcher
 
-class SimpleUriRouter<RES>(private val logger: UriRouterLogger? = null) : UriRouter<RES>(logger) {
+class SimpleUriRouter<RES>(
+    private val logger: UriRouterLogger? = null,
+    dataHolder: MutableMap<DeepLinkEntry, EntryValue<RES>> = mutableMapOf()
+) : UriRouter<RES>(logger) {
 
-    private val entries: MutableMap<DeepLinkEntry, EntryValue<RES>> = mutableMapOf()
+    private val entries: MutableMap<DeepLinkEntry, EntryValue<RES>> = dataHolder
 
     override fun resolveEntry(route: String): Pair<DeepLinkEntry, EntryValue<RES>>? {
         logger?.invoke("Entries size: ${entries.size}")

--- a/core/src/main/java/nolambda/linkrouter/UriRouter.kt
+++ b/core/src/main/java/nolambda/linkrouter/UriRouter.kt
@@ -17,13 +17,9 @@ abstract class UriRouter<RES>(
     private val logger: UriRouterLogger?
 ) : Router<String, RES?> {
 
-    internal val entries = ConcurrentHashMap<DeepLinkEntry, EntryValue<RES>>()
-
     abstract fun resolveEntry(route: String): Pair<DeepLinkEntry, EntryValue<RES>>?
 
     override fun resolve(route: String): RES? {
-        logger?.invoke("Entries size: ${entries.size}")
-
         val result = resolveEntry(route)
         if (result == null) {
             logger?.invoke("Path not implemented $route")
@@ -39,18 +35,9 @@ abstract class UriRouter<RES>(
         return value.handler.invoke(deepLinkUri, parameters)
     }
 
-    open fun addEntry(
+    abstract fun addEntry(
         vararg uri: String,
         matcher: UriMatcher = DeepLinkEntryMatcher,
         handler: UriRouterHandler<RES>
-    ) {
-        val deepLinkEntries = uri.map { DeepLinkEntry.parse(it) }
-        deepLinkEntries.forEach { entry ->
-            entries[entry] = EntryValue(handler, matcher)
-        }
-    }
-
-    override fun clear() {
-        entries.clear()
-    }
+    )
 }

--- a/core/src/test/java/nolambda/linkrouter/DeepLinkUriSpec.kt
+++ b/core/src/test/java/nolambda/linkrouter/DeepLinkUriSpec.kt
@@ -23,7 +23,7 @@ class DeepLinkUriSpec : StringSpec({
 
     "It should handle slash properly" {
         val deeplink = DeepLinkEntry.parse("nolambda://test/{a}/{b}")
-        val parameters = deeplink.getParameters("nolambda://test/a/b?aaaa")
+        val parameters = deeplink.getParameters("nolambda://test/a/b?aaaa=1")
 
         parameters.size shouldBe 2
         parameters["a"] shouldBe "a"

--- a/core/src/test/java/nolambda/linkrouter/PerformanceTest.kt
+++ b/core/src/test/java/nolambda/linkrouter/PerformanceTest.kt
@@ -12,8 +12,8 @@ class PerformanceTest : StringSpec({
     val logger = { log: String -> println(log) }
 
     val simpleRouter = SimpleUriRouter<Unit>(logger)
-    val keyRouter = KeyUriRouter<Unit>(logger) { entry ->
-        "${entry.uri.scheme}${entry.uri.host}"
+    val keyRouter = KeyUriRouter<Unit>(logger) {
+        "${it.scheme}${it.host}${it.pathSegments.size}"
     }
 
     val generateEntry = {

--- a/core/src/test/java/nolambda/linkrouter/UriRouterSpec.kt
+++ b/core/src/test/java/nolambda/linkrouter/UriRouterSpec.kt
@@ -8,56 +8,86 @@ import nolambda.linkrouter.matcher.UriMatcher
 
 class UriRouterSpec : StringSpec({
 
-    val createTestRouter = { SimpleUriRouter<String>() }
+    val routers = listOf(
+        SimpleUriRouter<String>(),
+        KeyUriRouter { "${it.scheme}${it.host}" }
+    )
 
     "it should match and resolve to respected path" {
+        routers.forEach { router ->
+            val pathMap = mapOf(
+                "http://test.com/promo" to "1",
+                "http://test.com/promo-list" to "2",
+                "http://test.com/promo-list/promo/" to "3",
+                "http://test.com/promo-list/item1" to "4",
+                "http://test.com/promo-list/item2" to "5",
+                "http://test.com/promo-list/item3" to "6",
+                "http://test.com/promo-list/item4" to "7",
+                "http://test.com/promo-list/{a}" to "8",
+            )
 
-        val router = createTestRouter()
-        val pathMap = mapOf(
-            "http://test.com/promo" to "1",
-            "http://test.com/promo-list" to "2",
-            "http://test.com/promo-list/promo/" to "3",
-            "http://test.com/promo-list/{a}" to "4",
-        )
+            println("Using $router")
 
-        pathMap.keys.forEach { key ->
-            router.addEntry(key) { _, param ->
-                println("Param: $param")
-                pathMap[key] ?: error("")
+            pathMap.keys.forEach { key ->
+                router.addEntry(key) { _, param ->
+                    println("Param: $param")
+                    pathMap[key] ?: error("")
+                }
             }
-        }
 
-        pathMap.keys.forEach { key ->
-            val resolved = router.resolve(key)
+            pathMap.keys.forEach { key ->
+                val resolved = router.resolve(key)
 
-            println("Expected -> $key : ${pathMap[key]}")
-            println("Actual -> $key : $resolved")
-            println("------")
+                println("Expected -> $key : ${pathMap[key]}")
+                println("Actual -> $key : $resolved")
+                println("------")
 
-            resolved shouldBe pathMap[key]
+                resolved shouldBe pathMap[key]
+            }
         }
     }
 
     "it should match normal regex" {
-        val router = createTestRouter()
-        router.addEntry("http://something.com/.*/{a}") { _, param -> param["a"].orEmpty() }
-        val result = router.resolve("http://something.com/aaaa/true")
+        routers.forEach { router ->
+            router.addEntry("http://something.com/.*/{a}") { _, param -> param["a"].orEmpty() }
+            val result = router.resolve("http://something.com/aaaa/true")
 
-        result shouldBe "true"
+            result shouldBe "true"
+        }
+    }
+
+    "it should ignore extra path in url" {
+        routers.forEach { router ->
+            router.addEntry("https://example.com/test/{page}/extra") { _, _ -> "" }
+            val result = router.resolve("https://example.com/test/2")
+
+            result shouldBe null
+        }
+    }
+
+    "it should match url with extra query parameter" {
+        routers.forEach { router ->
+            val expectedResult = "hi!"
+            router.addEntry("https://example.com/test/{page}") { _, _ -> expectedResult }
+            val result = router.resolve("https://example.com/test/2?utm_source=facebook.com")
+
+            result shouldBe expectedResult
+        }
     }
 
     "it should match custom matcher" {
-        val expectedResult = "123"
-        val router = createTestRouter()
-        router.addEntry("https://test.com?show=true", matcher = object : UriMatcher {
-            override fun match(entry: DeepLinkEntry, url: String): Boolean {
-                return DeepLinkEntryMatcher.match(entry, url) && url.toDeepLinkUri()
-                    .queryParameter("show") == "true"
-            }
-        }) { _, _ -> expectedResult }
+        routers.forEach { router ->
+            val expectedResult = "123"
+            router.addEntry("https://test.com?show=true", matcher = object : UriMatcher {
+                override fun match(entry: DeepLinkEntry, url: String): Boolean {
+                    return DeepLinkEntryMatcher.match(entry, url) && url.toDeepLinkUri()
+                        .queryParameter("show") == "true"
+                }
+            }) { _, _ -> expectedResult }
 
 
-        router.resolve("https://test.com?show=false") shouldBe null
-        router.resolve("https://test.com?show=true") shouldBe expectedResult
+            router.resolve("https://test.com?show=false") shouldBe null
+            router.resolve("https://test.com?show=true") shouldBe expectedResult
+        }
     }
 })


### PR DESCRIPTION
## Description

1. Re-work `KeyUriRouter`, it now creates `DeepLinkEntry` on-demand and memoizes it to make it faster.
2. Replace `ConcurrentHashMap` for `UriRouter`, now each implementation of `UriRouter` has its own data holder model
3. Add documentation and a clearer guide to use `LazyRegisterStrategy`.